### PR TITLE
Upgrade to request@2.44.0.  Current version has a vulnerability in qs (https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lru-cache": "~2.3.1",
     "lockfile": "~0.4.2",
     "lodash": "~2.2.1",
-    "request": "~2.27.0",
+    "request": "~2.44.0",
     "xregexp": "~2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to request@2.44.0.  Current version has a vulnerability in qs ([https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking](https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking))
