### PR TITLE
Fix REDOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,13 @@ exports.parse = function(userAgent) {
     deviceInfoUrl: 'unknown',
   };
 
+  /* Many patterns are vulnerable to REDOS. */
+  var MAX_REASONABLE_LENGTH = 1000;
+  if (MAX_REASONABLE_LENGTH < userAgent.length) {
+    return finalizeResult(result);
+  }
+
+
   for(var i = 0; i < cache.robots.order.length; i++) {
     var robotId = cache.robots.order[i];
     var robot = cache.robots[robotId];


### PR DESCRIPTION
This PR addresses security issues I disclosed by email.

Problem:
Many of the regexes are vulnerable to catastrophic backtracking.
A malicious userAgent string could lead to REDOS.

Solution:
Enforce maximum userAgent string length.

Effectiveness:
None of the regexes have an exponential blow-up.
The worst I observed would blow up with 2K characters.
This regex takes around a tenth of a second on a 1K attack string.
The others take on the order of milliseconds or faster.

@n1474335